### PR TITLE
feature: fix cursor jump issue and implement line breaks using innerText

### DIFF
--- a/src/components/Presentation/SlideCanvasLayout/Object/Textbox/index.jsx
+++ b/src/components/Presentation/SlideCanvasLayout/Object/Textbox/index.jsx
@@ -34,9 +34,9 @@ function EditableTextBox({ spec }) {
     },
   );
 
-  const handleTextBoxContentChange = debounce((event) => {
+  const handleTextBoxContentChange = throttle((event) => {
     const updateData = {};
-    updateData[selectedObjectType] = { content: event.target.textContent };
+    updateData[selectedObjectType] = { content: event.target.innerText };
     textBoxContentMutation.mutate(updateData);
   }, 500);
 
@@ -317,6 +317,7 @@ const EditableDiv = styled.div`
   border: none;
   overflow: auto;
   outline: none;
+  white-space: pre-wrap;
   color: ${({ spec }) => spec.textColor};
   font-size: ${({ spec }) => spec.fontSize}px;
   font-family: ${({ spec }) => spec.fontFamily};


### PR DESCRIPTION
## 개요
contenteditable Textbox에서 커서의 위치가 좌측 상단으로 점프하는 현상과
줄 바꿈이 일정 시간 이후에 무효화 되고 한 줄로 이어지는 현상을 수정했습니다. 

## 작업사항
기존의 debounce를 사용한 로직에서 throttle을 사용한 로직으로 변경하면서, cursor가 마음대로 점프하는 현상을 해결했습니다. 
사용자가 타이핑을 하고 있을 때, 내부 상태 업데이트나 네트워크 요청이 debounce 시간 간격 후에 일어나면서 커서 위치가 리셋되는 현상이 있었습니다. 이렇게 cursor가 점프하는 현상으로 인해 텍스트를 입력하는데 어려움이 있었습ㄴ디ㅏ. 
throttle을 사용해서 입력 중에도 일정한 간격으로 함수가 호출되어 상태 업데이트가 더 자주 일어나게 되고, 커서 위치를 보다 안정적으로 유지할 수 있도록 해주었습니다.

그리고 기존에 textContent로 작성되어있던 로직은 요소의 실제 텍스트 콘텐츠를 가져오는데, 스타일이 적용되지 않은 텍스트 만을 가져오기 떄문에 레이아웃에 의한 줄 바꿈은 반영되지 않는 현상이 있었습니다. 
textContent가 아닌, innerText는 요소의 렌더링된 텍스트 콘텐츠만을 반영합니다. 즉, 사용자가 보는 그대로의 텍스트를 가져옵니다. (스타일이나 스크립트에 의해 숨겨진 텍스트는 제외합니다). innerText는 줄바꿈을 인식하고 유지할 수 있었습니다. 

즉, 사용자가 입력한 줄 바꿈을 그대로 유지하려고 하는 경우에는 기존에 사용했던 textContent가 아닌 innerText를 이용한 방법으로 해결할 수 있었습니다. 